### PR TITLE
Route for delete task fixed

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -15,7 +15,8 @@ class TasksController < ApplicationController
 
   # GET /tasks/new
   def new
-    @task = Task.new
+    # @task = Task.new
+    @task = current_user.categories.tasks.build
   end
 
   # GET /tasks/1/edit
@@ -24,7 +25,7 @@ class TasksController < ApplicationController
 
   # POST /tasks or /tasks.json
   def create
-    @category = Category.find(params[:category_id])
+    @category = current_user.categories.find(params[:category_id])
     @task = @category.tasks.create(task_params)
     redirect_to category_path(@category)
     
@@ -45,14 +46,14 @@ class TasksController < ApplicationController
 
   # DELETE /tasks/1 or /tasks/1.json
   def destroy
-    @category = Category.find(params[:category_id])
+    @category = current_user.categories.find(params[:category_id])
     @task = @category.tasks.find(params[:id])
     @task.destroy
     redirect_to category_path(@category)
   end
 
   def correct_user
-    @task = current_user.categories.tasks.find_by(id: params[:id])
+    @category = current_user.categories.find(params[:category_id])
     redirect_to categories_path, notice: "Not authorized to perform this action."  if @category.nil?
 end
 

--- a/spec/features/delete_task_spec.rb
+++ b/spec/features/delete_task_spec.rb
@@ -1,20 +1,24 @@
 require 'rails_helper'
 
+class DeleteTasksTests < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+end
+
+
 RSpec.feature "DeleteTasks", type: :feature do
   before do 
     @user = User.create!(email: 'test@test.com', password: 'test123')
     @category = @user.categories.create!(title: 'Food')
     @task = @category.tasks.create!(header: "Make lunch", description: "Have a good lunch!")
+    sign_in(@user)
   end
 
   it 'deletes a task from the category show' do
     visit "/categories/#{@category.id}"
 
-    click_on "Delete Task"
-
+    expect { click_on "Delete Task" }.to change { Task.count }.by(-1)
+    
     expect(page).not_to have_content("Make lunch")
     expect(page).not_to have_content("Have a good lunch!")
-
-    expect { @task.destroy }.to change { Task.count }.by(-1)
   end
 end


### PR DESCRIPTION
- [x] Fixed correct_user method 
- [x] Deleting task now redirects properly and deletes task from user.category 